### PR TITLE
Save packs order / disabled on menu closed

### DIFF
--- a/Types/UI_RHPacksList.cs
+++ b/Types/UI_RHPacksList.cs
@@ -37,6 +37,14 @@ public class UI_RHPacksList : MonoBehaviour
         CoroutineDispatcher.Dispatch(EnableCoroutine());
     }
 
+    public void OnDisable() {
+        if (ResourcePacksManager.LoadedPacks.Count != 0)
+        {
+            ResourcePacksManager.SavePackOrder();
+            ResourcePacksManager.SaveDisabledPacks();
+        }
+    }
+
     void ClearList()
     {
         if (container == null || packTemplate == null) return;


### PR DESCRIPTION
unless you have lazy loading disabled pack order / disabled status will not save unless you hit reload packs. With this its going to save when exiting the menu without completely reloading all packs